### PR TITLE
Fix res_mkquery ordering issue and change class/type

### DIFF
--- a/nslookup.c
+++ b/nslookup.c
@@ -250,7 +250,7 @@ int main(int argc, char *argv[])
 
 	/* build the query */
 	unsigned char query[280];
-	int qlen = res_mkquery(0, name, ns_t_a, ns_c_any, 0, 0, 0,
+	int qlen = res_mkquery(0, name, ns_c_in, ns_t_ptr, 0, 0, 0,
 			       query, sizeof(query));
 	if (qlen < 0) {
 		fprintf(stderr, "cannot build the query\n");


### PR DESCRIPTION
Noticed that the ordering of the class and type fields where swapped: https://linux.die.net/man/3/res_mkquery

Also I changed the class from ANY to IN due to deprecation that is occurring on many DNS servers: https://blog.cloudflare.com/deprecating-dns-any-meta-query-type/